### PR TITLE
Bugfix losing last match

### DIFF
--- a/src/bin/test-multi-apply.rs
+++ b/src/bin/test-multi-apply.rs
@@ -143,7 +143,7 @@ fn test(regex_src: &RegexSource, text_src: &TextSource) {
     translator.print_prog();
 
 
-    let mut interpreter = ThompsonInterpreter::new(&translator.prog);
+    let mut interpreter = ThompsonInterpreter::new(translator.prog);
     let text = &text_src.get_text();
     println!("{}", text);
     interpreter.apply(&text);
@@ -151,7 +151,7 @@ fn test(regex_src: &RegexSource, text_src: &TextSource) {
         println!("There were no matches");
     } else {
         for m in interpreter.matches {
-            println!("There was a match from position 0 to {} (rule {})", m.pos, m.rule);
+            println!("There was a match from position 0 to {} (rule {})", m.len, m.rule);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod reinterp;
 mod reterm;
 pub mod reprog;
 mod sparse;
+mod util;

--- a/src/reinterp.rs
+++ b/src/reinterp.rs
@@ -14,7 +14,7 @@ use std::mem::swap;
 use reprog::*;
 use sparse::SparseSet; // cribbed from regex crate, and from its ancestors
 use reprog::Instruction::*;
-
+use util::char_at;
 
 
 struct TaskList {
@@ -39,7 +39,7 @@ impl TaskList {
     }
 
     pub fn add_task(&mut self, pc: Label) {
-        println!("Adding task with pc = {}", pc);
+        //println!("Adding task with pc = {}", pc);
         if !self.t.contains(pc) {
             self.t.insert(pc);
         }
@@ -47,33 +47,62 @@ impl TaskList {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct MatchRecord {
-    pub pos: usize,
+    pub len: usize,
     pub rule: usize,
 }
 
 impl MatchRecord {
     pub fn new(p: usize, r: usize) -> MatchRecord {
-        MatchRecord { pos: p, rule: r }
+        MatchRecord { len: p, rule: r }
     }
 }
 
 
 
-pub struct ThompsonInterpreter<'a> {
+pub struct ThompsonInterpreter {
     pub matches: Vec<MatchRecord>, // string positions where matches ended
-    prog: &'a Program,
+    prog: Program,
 }
 
-impl<'a> ThompsonInterpreter<'a> {
-    pub fn new(p: &Program) -> ThompsonInterpreter {
+impl ThompsonInterpreter {
+    
+    pub fn new(p: Program) -> ThompsonInterpreter {
         ThompsonInterpreter {
             matches: vec![],
             prog: p,
         }
     }
 
+    fn best_match(&self) -> Option<MatchRecord> {
+        if self.matches.is_empty() {
+            return None;
+        }
+        let mut best = MatchRecord {len: 0, rule: 0};
+        for m in &self.matches {
+            if m.len > best.len {
+                best = m.clone();
+            } else if m.len == best.len {
+                if m.rule < best.rule {
+                    best = m.clone();
+                }
+            }
+            // else m.len < best.len, and we continue
+        }
+        Some(best)
+    }
+
+    /**
+     * Loop through clist. Epsilon transitions (Split) add new entries to clist,
+     * so this implements epsilon-closure. All other instructions add new 
+     * entries to nlist.
+     * So this will apply all character tests to the current character, and
+     * return when it is done.
+     * There is no direct notion of failure here. If nothing is added to nlist,
+     * then the whole procedure will terminate. There is a global notion of
+     * failure which can be checked then, namely were there any matches. 
+     */
     fn step(
         &mut self, 
         str_pos: usize, 
@@ -81,26 +110,29 @@ impl<'a> ThompsonInterpreter<'a> {
         clist: &mut TaskList, 
         nlist: &mut TaskList
     ) {
-        println!("str_pos = {}", str_pos);
+        println!("step: '{}'", ch);
         let mut i: usize = 0;
         loop {
             if i >= clist.len() {
+                println!("finished with clist, end of match step");
                 return; // really we want to break out of the outer loop here...
             }
 
             let pc = clist.t.at(i);
             i += 1;
 
-            println!("Executing instruction at line {}", pc);
+            //println!("Executing instruction at line {}", pc);
             let inst = &self.prog[pc];
             match *inst {
                 Char(ref data) => {
                     if data.ch == ch {
+                        //println!("Matched '{}' at string pos {}", data.ch, str_pos);
                         //println!("Add task to nlist at {}", pc + 1);
                         nlist.add_task(data.goto);
                     } else if data.nocase {
                         if data.ch.to_lowercase().collect::<String>() == 
                            ch.to_lowercase().collect::<String>() {
+                            //println!("i-Matched '{}' at string pos {}", data.ch, str_pos);
                             nlist.add_task(data.goto);
                         }
                     }
@@ -111,15 +143,17 @@ impl<'a> ThompsonInterpreter<'a> {
                 }
                 CharClass(ref ccd) => {
                     if ccd.data.matches(ch) {
+                        //println!("CharClass {} matches {} at {}", ccd.data, ch, str_pos);
                         nlist.add_task(ccd.goto);
                     } else if ccd.nocase {
                         if ccd.data.matches(ch.to_lowercase().next().unwrap()) {
+                            //println!("CharClass {} i-matches {} at {}", ccd.data, ch, str_pos);
                             nlist.add_task(ccd.goto);
                         }
                     }
                 }
                 Match(ref data) => {
-                    //println!("Match");
+                    //println!("Match: {} [{}]", str_pos, data.rule_id);
                     self.matches.push(MatchRecord::new(str_pos, data.rule_id));
                 }
                 Split(l1, l2) => {
@@ -134,31 +168,133 @@ impl<'a> ThompsonInterpreter<'a> {
     }
 
 
+/*
+    /**
+     * Return Some((ch, next_pos)) if there is a character at pos in text,
+     * None otherwise.
+     */
+    fn char_at(text: &str, pos: usize) -> Option<(char, usize)> {
+        static HI_BIT: u8 = 0b1000_0000;
+        if pos >= text.len() {
+            return None; 
+        }
+        let leader: u8 = text.as_bytes()[pos];
+        let mut length = 1;
+        if leader & HI_BIT == 0 {
+            return Some((leader as char, pos + length));
+        }
+        let mut bits: u32;
+        if leader >= 0b1111_0000 {
+            bits = (leader & 0b0000_0111) as u32;
+            length = 4;
+        } else if leader >= 0b1110_0000 {
+            bits = (leader & 0b0000_1111) as u32;
+            length = 3;
+        } else if leader >= 0b1100_0000 {
+            bits = (leader & 0b0001_1111) as u32;
+            length = 2;
+        } else {
+            unreachable!();
+        }
+        
+        for i in 1..length {
+            let byte: u8 = text.as_bytes()[pos + i];
+            bits = (bits << 6) | (byte & 0b0011_1111) as u32;
+        }
+        match ::std::char::from_u32(bits) {
+            None => None,
+            Some(ch) => Some((ch, pos + length))
+        }
+    }
+*/
 
     /**
-     * Returns?
-     * Success/Failure (Option?)
-     * On Success, something including the match span...
+     * Find a token starting at &text[begin..], if possible.
+     * Results are stored in self.matches, and so "failure" is indicated
+     * by an empty match list.
      */
-    pub fn apply(&mut self, text: &str) {
+    fn all_matches_at(&mut self, text: &str) {
+
+        println!("text: '{}'", text);
 
         let plen = self.prog.len();
         let mut clist = TaskList::new(plen);
         let mut nlist = TaskList::new(plen);
 
+        self.matches.clear();
+
         for start in &self.prog.starts {
-            println!(">> Adding entry point {} to clist", *start);
+            //println!(">> Adding entry point {} to clist", *start);
             clist.add_task(*start);
         }
-        for (str_pos, ch) in text.char_indices() {
-            if clist.is_empty() {
-                println!(">> clist empty -- bailing out");
-                break;
+        let mut pos;
+        let mut nxt = 0;
+        let mut ch: char;
+        while !clist.is_empty() {
+
+            pos = nxt;
+
+            match char_at(&text[pos..] /*text, pos*/) {
+                None => { 
+                    println!("char_at returned None");
+                    // BUG: There might not be a valid next character, 
+                    // if we are just waiting on execution of a Match 
+                    // instruction...
+                    return;
+                    // I think this has to be an error:
+                    panic!("ERROR: Could not decode character at {}", pos);
+                }
+                Some((c, p)) => {
+                    nxt = p;
+                    ch = c;
+                    //println!("pos: {}; nxt: {}; ch: '{}'", pos, nxt, ch);
+                }
             }
-            self.step(str_pos, ch, &mut clist, &mut nlist);
+
+            self.step(pos, ch, &mut clist, &mut nlist);
             // rebind clist and nlist
             swap(&mut clist, &mut nlist);
             nlist.clear();
+        }
+    }
+
+    /**
+     * Loops over the characters in the input, but will exit early if
+     * we ever reach a point where nothing in the input matches.
+     * Then clist will be empty.
+     * Currently, we have no way of knowing what caused termination
+     * (out of string? no surviving threads?). It is just a matter of
+     * whether there were any matches at that point.
+     * 
+     * This is not quite correct. There should be an outer loop which 
+     * consumes the string, and an inner loop which finds matches.
+     * When we are done looking for matches (clist is empty), we bump
+     * our string position to either the end of the best match (if there
+     * were any) or one position forward (if there were no matches).
+     *
+     * That latter is assuming that we do not require a match of some kind
+     * on every character. Otherwise we have to fail harder in cases where
+     * the match list comes back empty.
+     */
+    pub fn apply(&mut self, text: &str) {
+
+        let mut pos: usize = 0;
+        while pos < text.len() {
+            self.all_matches_at(&text[pos..]);
+            // Now, what is our best match, if any? 
+            match self.best_match() {
+                None => {
+                    // increment pos by 1 and try again
+                    println!("No rule matched at pos {}", pos);
+                    pos += 1;
+                }
+                Some(mtch) => {
+                    // emit a token
+                    println!("TOKEN: {} -> {} [{}]", pos, pos + mtch.len, mtch.rule);
+                    // increment pos by mtch length and continue
+                    pos += mtch.len;
+                }
+            }
         }
     }
 }

--- a/src/reprog.rs
+++ b/src/reprog.rs
@@ -8,6 +8,7 @@ use reterm::CharClassData;
 
 pub type Label = usize;
 
+#[derive(Debug)]
 pub enum Instruction {
     Char(CharInstData),
     AnyChar(AnyCharInst),
@@ -17,21 +18,25 @@ pub enum Instruction {
 }
 
 
+#[derive(Clone, Copy, Debug)]
 pub struct CharInstData {
     pub ch: char,
     pub nocase: bool,
     pub goto: Label,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct AnyCharInst {
     pub goto: Label,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct MatchInst {
     pub rule_id: usize,
     //pub goto: Label,
 }
 
+#[derive(Debug)]
 pub struct CharClassInst {
     pub data: CharClassData,
     pub nocase: bool,
@@ -59,6 +64,7 @@ impl fmt::Display for Instruction {
 
 
 
+#[derive(Debug)]
 pub struct Program {
     code: Vec<Instruction>,
     pub starts: Vec<usize>,         // entry points

--- a/src/reterm.rs
+++ b/src/reterm.rs
@@ -114,13 +114,13 @@ impl CharClassData {
         for pred in &self.ranges {
             match *pred {
                 Range(c1, c2) => {
-                    println!("Range({}, {})", c1, c2);
+                    //println!("Range({}, {})", c1, c2);
                     if ch >= c1 && ch <= c2 && self.positive {
                          return true;
                     }
                 }
                 Individual(c1) => {
-                    println!("Individual({})", c1);
+                    //println!("Individual({})", c1);
                     if c1 == ch && self.positive {
                         return true;
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,42 @@
+
+/**
+ * Return Some((ch, len)) if there is a character at the start of text,
+ * None otherwise.
+ */
+pub fn char_at(text: &str) -> Option<(char, usize)> {
+    static HI_BIT: u8 = 0b1000_0000;
+    if text.is_empty() {
+        return None; 
+    }
+    let leader: u8 = text.as_bytes()[0];
+    let mut length = 1;
+    if leader & HI_BIT == 0 {
+        return Some((leader as char, length));
+    }
+    let mut bits: u32;
+    if leader >= 0b1111_0000 {
+        bits = (leader & 0b0000_0111) as u32;
+        length = 4;
+    } else if leader >= 0b1110_0000 {
+        bits = (leader & 0b0000_1111) as u32;
+        length = 3;
+    } else if leader >= 0b1100_0000 {
+        bits = (leader & 0b0001_1111) as u32;
+        length = 2;
+    } else {
+        unreachable!();
+    }
+
+    if text.len() < length {
+        panic!("UTF-8 cutoff error: String does not contain a whole character");
+    }
+    
+    for i in 1..length {
+        let byte: u8 = text.as_bytes()[i];
+        bits = (bits << 6) | (byte & 0b0011_1111) as u32;
+    }
+    match ::std::char::from_u32(bits) {
+        None => None,
+        Some(ch) => Some((ch, length))
+    }
+}


### PR DESCRIPTION
If we run out of string we abandon current tasks. But epsilon transitions are still valid, and Match is an epsilon transition. So we were losing valid matches at the end of the string (e.g., document final punctuation). Fixed now: if char_at returns None, we check to see whether it was a bad UTF-8 sequence or we are at the end of the string. There might be more elegant fixes possible...
